### PR TITLE
perf(video): try av_hwframe_map before av_hwframe_transfer_data

### DIFF
--- a/include/irl-source.h
+++ b/include/irl-source.h
@@ -104,6 +104,11 @@ struct irl_source {
 	int audio_stream_idx;
 	int video_stream_idx;
 	bool using_hw_decode;
+	/* Tri-state: -1 = not yet attempted, 0 = map fails, falling back
+	 * to transfer_data, 1 = map succeeded at least once. Used to
+	 * skip the doomed map attempt on the second frame onwards once
+	 * we've learned the platform can't map. */
+	int hw_map_ok;
 
 	/* Resampler (planar → interleaved float) */
 	SwrContext *swr_ctx;

--- a/src/receiver-stream.c
+++ b/src/receiver-stream.c
@@ -168,6 +168,7 @@ void irl_close_ffmpeg(struct irl_source *ctx)
 	ctx->video_stream_idx = -1;
 	ctx->using_hw_decode = false;
 	ctx->hw_device_type = AV_HWDEVICE_TYPE_NONE;
+	ctx->hw_map_ok = -1;
 }
 
 static int interrupt_cb(void *opaque)

--- a/src/video-handler.c
+++ b/src/video-handler.c
@@ -193,16 +193,55 @@ static uint64_t frame_timestamp(struct irl_source *ctx, const AVFrame *frame)
 
 void irl_video_output_frame(struct irl_source *ctx, AVFrame *frame)
 {
-	/* Hardware-decoded frames (NVDEC/D3D11VA/VAAPI) need to be transferred to CPU */
+	/* Hardware-decoded frames (NVDEC/D3D11VA/VAAPI/VideoToolbox) come
+	 * out on the GPU; we have to expose them to OBS as system memory.
+	 *
+	 * Try av_hwframe_map(AV_HWFRAME_MAP_READ) first: on backends that
+	 * can produce a CPU-readable view without a full download (VAAPI
+	 * vaDeriveImage, VideoToolbox IOSurface), this skips the
+	 * gpu->cpu copy entirely. On D3D11VA / CUDA the map call falls
+	 * back to a copy internally or fails, so we fall back to
+	 * av_hwframe_transfer_data which is the historical path.
+	 *
+	 * hw_map_ok caches the outcome so we don't keep paying for a
+	 * doomed map attempt every frame on platforms that can't map. */
 	AVFrame *sw_frame = NULL;
 	if (frame->hw_frames_ctx) {
 		sw_frame = av_frame_alloc();
 		if (!sw_frame)
 			return;
-		if (av_hwframe_transfer_data(sw_frame, frame, 0) < 0) {
-			av_frame_free(&sw_frame);
-			return;
+
+		bool used_map = false;
+		if (ctx->hw_map_ok != 0) {
+			int ret = av_hwframe_map(sw_frame, frame,
+						 AV_HWFRAME_MAP_READ);
+			if (ret == 0) {
+				used_map = true;
+				if (ctx->hw_map_ok != 1) {
+					ctx->hw_map_ok = 1;
+					blog(LOG_INFO,
+					     "[irl-source] HW frame path: av_hwframe_map (zero-copy)");
+				}
+			} else {
+				av_frame_unref(sw_frame);
+				if (ctx->hw_map_ok != 0) {
+					ctx->hw_map_ok = 0;
+					char errbuf[AV_ERROR_MAX_STRING_SIZE];
+					av_strerror(ret, errbuf, sizeof(errbuf));
+					blog(LOG_INFO,
+					     "[irl-source] HW frame path: av_hwframe_transfer_data (map unsupported: %s)",
+					     errbuf);
+				}
+			}
 		}
+
+		if (!used_map) {
+			if (av_hwframe_transfer_data(sw_frame, frame, 0) < 0) {
+				av_frame_free(&sw_frame);
+				return;
+			}
+		}
+
 		sw_frame->pts = frame->pts;
 		sw_frame->colorspace = frame->colorspace;
 		sw_frame->color_range = frame->color_range;


### PR DESCRIPTION
av_hwframe_map(AV_HWFRAME_MAP_READ) can produce a CPU-readable view of a HW-decoded frame without a full GPU->CPU download on backends that support it: VAAPI via vaDeriveImage on Linux, VideoToolbox via IOSurface mapping on macOS. on D3D11VA the call typically does an internal copy or fails outright, in which case we fall back to the historical av_hwframe_transfer_data path with no behaviour change.

ctx->hw_map_ok caches the outcome so we don't pay for a doomed map attempt on every frame after the first failure. the chosen path is logged once per stream so it's visible without a profiler.

OBS copies the mapped data synchronously into its async queue during obs_source_output_video, so freeing sw_frame at the end of irl_video_output_frame correctly releases the mapping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved video frame handling for hardware acceleration to prevent repeated failed mapping attempts
  * Enhanced decoder shutdown to properly reset frame mapping state

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/irlserver/obs-irl-source/pull/3)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->