### PR TITLE
fix(network): stop handing librist a byte count as buffer_size

### DIFF
--- a/src/receiver-stream.c
+++ b/src/receiver-stream.c
@@ -15,6 +15,17 @@
 
 #include "receiver-internal.h"
 
+/* Protocol test on the scheme itself, not a substring of the whole URL: a
+ * query parameter or a path segment must not decide which options apply. */
+static bool url_has_scheme(const char *url, const char *scheme)
+{
+	if (!url)
+		return false;
+	size_t len = strlen(scheme);
+	return strncmp(url, scheme, len) == 0 &&
+	       strncmp(url + len, "://", 3) == 0;
+}
+
 static void apply_demuxer_options(AVDictionary **opts, const char *url,
 				  const char *extra, int network_buffer_mb)
 {
@@ -42,22 +53,43 @@ static void apply_demuxer_options(AVDictionary **opts, const char *url,
 	 */
 	av_dict_set(opts, "tls_verify", "0", 0);
 
+	/*
+	 * The receive buffer is a byte count, and FFmpeg 9.0 spells that two
+	 * different ways, so both names have to be set to cover the protocols
+	 * this plugin ingests.
+	 *
+	 * "buffer_size" is bytes for udp:// (setsockopt SO_RCVBUF), and for
+	 * rtp:// and rtsp://, which forward it verbatim to the udp:// they open.
+	 * librist is the one protocol that reuses the name for something else:
+	 * there it is the RIST recovery window in *milliseconds*, declared with
+	 * a max of 30000. A byte count therefore makes av_opt_set_dict() on the
+	 * URLContext fail with AVERROR(ERANGE) ("Result too large") and
+	 * avformat_open_input aborts before a socket is ever opened. rist://
+	 * keeps librist's own recovery default instead, which is tuned per
+	 * stream through the URL's buffer= parameter that rist_parse_address2()
+	 * reads.
+	 *
+	 * "recv_buffer_size" is bytes for tcp:// (SO_RCVBUF) and for libsrt
+	 * (SRTO_UDP_RCVBUF), and nothing else declares it. It reaches tcp://
+	 * from every protocol layered on top of it, because rtmp_open,
+	 * http_open_cnx and ff_tls_open_underlying each thread the caller's
+	 * option dictionary down into the transport they open — so this is what
+	 * gives the setting any effect at all on rtmp(s):// and http(s)://.
+	 *
+	 * Each name is ignored by the protocols that want the other one, so
+	 * neither needs a scheme test beyond the rist:// exclusion.
+	 */
 	if (network_buffer_mb > 0) {
-		char buf_size[32];
-		snprintf(buf_size, sizeof(buf_size), "%d",
+		char bytes[32];
+		snprintf(bytes, sizeof(bytes), "%d",
 			 network_buffer_mb * 1024 * 1024);
-		av_dict_set(opts, "buffer_size", buf_size, 0);
+		if (!url_has_scheme(url, "rist"))
+			av_dict_set(opts, "buffer_size", bytes, 0);
+		av_dict_set(opts, "recv_buffer_size", bytes, 0);
 	}
 
-	if (url && strstr(url, "srt://")) {
+	if (url_has_scheme(url, "srt"))
 		av_dict_set(opts, "latency", "200000", 0);
-		if (network_buffer_mb > 0) {
-			char recv_buf[32];
-			snprintf(recv_buf, sizeof(recv_buf), "%d",
-				 network_buffer_mb * 1024 * 1024);
-			av_dict_set(opts, "recv_buffer_size", recv_buf, 0);
-		}
-	}
 
 	if (extra && *extra) {
 		char *dup = av_strdup(extra);


### PR DESCRIPTION
Every rist:// ingest failed to open with "Result too large":

  [irl-source] Connecting to: rist://.../
  [irl-source] Failed to open input: Result too large
  [irl-source] Reconnecting in 2s...

apply_demuxer_options set "buffer_size" to network_buffer_mb in bytes for every URL. Four things in FFmpeg 9.0's libavformat declare that option name, and three of them agree it is a byte count: udp.c (which feeds it to setsockopt SO_RCVBUF), rtpproto.c and rtsp.c (which both forward it to the udp:// they open). librist.c is the outlier — there it is the RIST recovery window in milliseconds, declared 0..30000:

  { "buffer_size", "set buffer_size in ms", OFFSET(buffer_size),
    AV_OPT_TYPE_INT, {.i64=0}, 0, 30000, .flags = D|E },

2 MB is 2097152, so av_opt_set_dict() on the URLContext rejected it with AVERROR(ERANGE) and ffurl_open failed before librist opened a socket. The byte-semantic protocols all declare -1..INT_MAX and had been taking the value silently, which is why only RIST surfaced it. rist:// now keeps librist's own recovery default, tuned per stream by the URL's buffer= parameter that rist_parse_address2() reads.

While here, extend the receive buffer to the TCP-based protocols. It was only ever applied to srt:// as "recv_buffer_size", but tcp.c declares that same option (SO_RCVBUF), and rtmp_open, http_open_cnx and ff_tls_open_underlying each thread the caller's option dictionary down into the transport they open. So one unconditional set now gives the buffer effect on rtmp(s)://, http(s):// and tcp:// as well, where "buffer_size" had been landing in the dictionary unread. Only tcp.c and libsrt.c declare the name and both are -1..INT_MAX, so it cannot ERANGE the way buffer_size did.

The srt:// test also moves from strstr(url, "srt://") to a scheme-prefix check, so a path segment or query parameter can no longer decide which protocol options apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL scheme detection so query and path text no longer incorrectly triggers protocol-specific settings.
  * Enhanced network buffering configuration for more consistent receive performance.
  * Refined SRT latency handling to apply only to valid SRT URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->