### PR TITLE
Fix non-recursive mutex issue on Linux

### DIFF
--- a/include/irl-threading.h
+++ b/include/irl-threading.h
@@ -169,7 +169,13 @@ typedef pthread_t irl_thread_t;
 
 static inline int irl_mutex_init(irl_mutex_t *m)
 {
-	return pthread_mutex_init(m, NULL);
+	pthread_mutexattr_t attr;
+	if (pthread_mutexattr_init(&attr) != 0)
+		return pthread_mutex_init(m, NULL);
+	pthread_mutexattr_settype(&attr, PTHREAD_MUTEX_RECURSIVE);
+	int ret = pthread_mutex_init(m, &attr);
+	pthread_mutexattr_destroy(&attr);
+	return ret;
 }
 
 static inline void irl_mutex_destroy(irl_mutex_t *m)


### PR DESCRIPTION
Fixes a self-deadlock in the audio pipeline that freezes video output and hangs OBS on Linux.

### Problem
While testing on Linux, I discovered an issue where OBS wouldn't receive an incoming video signal and would eventually hang completely. I managed to trace it back to the following:

* `audio_state_lock` uses a plain POSIX mutex which is non-recursive. On Windows, the equivalent (`CRITICAL_SECTION`) is recursive by default so this bug doesn't surface there. However on Linux (and macOS), locking the same mutex twice causes a deadlock on the thread.
* Once that happens the audio thread freezes permanently, and the video thread also gets stuck waiting on the same lock which stops it from reading the incoming video data.
* With nothing reading the video data, the network buffer fills up (logging "No room to store incoming packet" for each frame beyond the buffer) and OBS eventually hangs as it's waiting on these stuck threads.

### Fix
I updated the POSIX mutex to use `PTHREAD_MUTEX_RECURSIVE` so a thread can safely re-lock a mutex it already holds, matching the Windows behaviour.

### Notes
I've tested this as working on Linux (Ubuntu 24.04). As the changes sit outside the Win32 implementation, it shouldn't have any effect on Windows builds but would be worth testing just in case.

I'm not able to test this on macOS but, since it uses the same POSIX mutex path as Linux, this fix may be relevant to #9

I'm also not usually a C dev (Claude helped a lot with debugging this) so please review carefully, happy to make changes if there's a better way to handle this.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mutex initialization on non-Windows platforms by supporting recursive mutexes.
  * Added a safe fallback when recursive mutex setup is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->