### PR TITLE
fix: redact credentials from logged input URLs

### DIFF
--- a/src/irl-source.c
+++ b/src/irl-source.c
@@ -16,6 +16,40 @@
 
 /* ── Helpers ──────────────────────────────────────────────── */
 
+void irl_log_input_url(const char *action, const char *url)
+{
+	char protocol[32] = {0};
+	char hostname[256] = {0};
+	int port = -1;
+
+	/* Paths, userinfo, query parameters, and fragments can all contain
+	 * credentials. av_url_split lets the log retain the useful endpoint
+	 * identity without ever copying those components. */
+	av_url_split(protocol, sizeof(protocol), NULL, 0, hostname,
+		     sizeof(hostname), &port, NULL, 0, url ? url : "");
+
+	if (!protocol[0]) {
+		blog(LOG_INFO, "[irl-source] %s: <redacted>", action);
+		return;
+	}
+
+	bool ipv6 = strchr(hostname, ':') != NULL;
+	if (hostname[0] && port >= 0) {
+		blog(LOG_INFO, "[irl-source] %s: %s://%s%s%s:%d", action,
+		     protocol, ipv6 ? "[" : "", hostname, ipv6 ? "]" : "",
+		     port);
+	} else if (hostname[0]) {
+		blog(LOG_INFO, "[irl-source] %s: %s://%s%s%s", action,
+		     protocol, ipv6 ? "[" : "", hostname, ipv6 ? "]" : "");
+	} else if (port >= 0) {
+		blog(LOG_INFO, "[irl-source] %s: %s://<redacted>:%d", action,
+		     protocol, port);
+	} else {
+		blog(LOG_INFO, "[irl-source] %s: %s://<redacted>", action,
+		     protocol);
+	}
+}
+
 static void config_free(struct irl_config *cfg)
 {
 	if (cfg->url) {
@@ -488,8 +522,7 @@ void *irl_source_create(obs_data_t *settings, obs_source_t *source)
 		irl_source_get_stats, ctx);
 
 	if (ctx->config.url) {
-		blog(LOG_INFO, "[irl-source] Created with URL: %s",
-		     ctx->config.url);
+		irl_log_input_url("Created with URL", ctx->config.url);
 		start_receiver(ctx);
 	} else {
 		blog(LOG_INFO, "[irl-source] Created with no URL configured");

--- a/src/receiver-internal.h
+++ b/src/receiver-internal.h
@@ -2,6 +2,7 @@
 
 #include "../include/irl-source.h"
 
+void irl_log_input_url(const char *action, const char *url);
 uint64_t irl_audio_output_claim(struct irl_source *ctx, int frames,
 				int out_rate);
 void irl_reset_stream_timing_state(struct irl_source *ctx);

--- a/src/receiver-stream.c
+++ b/src/receiver-stream.c
@@ -426,7 +426,7 @@ static bool open_stream_attempt(struct irl_source *ctx, bool fast_probe)
 	apply_demuxer_options(&opts, ctx->config.url, ctx->config.ffmpeg_options,
 			      ctx->config.network_buffer_mb, fast_probe);
 
-	blog(LOG_INFO, "[irl-source] Connecting to: %s", ctx->config.url);
+	irl_log_input_url("Connecting to", ctx->config.url);
 
 	ctx->fmt_ctx = avformat_alloc_context();
 	if (!ctx->fmt_ctx) {


### PR DESCRIPTION
Closes [#16.](https://github.com/irlserver/obs-irl-source/issues/16)

This keeps the protocol/hostname and explicit port in the two input URL log messages while omitting userinfo paths query parameters and fragments.

For example:

`srt://user:password@relay.example.com:9000/live?passphrase=secret`

is now logged as:

`srt://relay.example.com:9000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL logging to protect sensitive information.
  * Logs now show only the protocol, hostname, and port while omitting paths, credentials, queries, and fragments.
  * Malformed or incomplete URLs are handled safely without exposing the original input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->