### PR TITLE
fix: respect disabled keyframe gate

### DIFF
--- a/include/irl-source.h
+++ b/include/irl-source.h
@@ -535,8 +535,8 @@ struct irl_source {
 
 	/* Keyframe gate.  Packet-level: don't feed the decoder at all
 	 * until a key packet arrives (avoids reference-miss error spam
-	 * and decoder churn on join).  Frame-level backstop:
-	 * first_keyframe_received gates decoded output. */
+	 * and decoder churn on join).  When enabled, the frame-level
+	 * backstop gates decoded output until first_keyframe_received. */
 	bool first_keyframe_received;
 	bool video_pkt_gate_open;
 	uint64_t video_pkt_gate_start_us;

--- a/src/receiver-video.c
+++ b/src/receiver-video.c
@@ -310,14 +310,16 @@ void irl_handle_video_frame(struct irl_source *ctx, AVFrame *frame)
 	}
 	frame->pts = pts;
 
-	if (!ctx->first_keyframe_received) {
-		if (!irl_video_is_keyframe(frame)) {
-			if (ctx->total_video_frames == 0)
-				blog(LOG_DEBUG,
-				     "[irl-source] Waiting for keyframe (dropped non-keyframe)");
-			return;
-		}
+	bool is_keyframe = irl_video_is_keyframe(frame);
+	if (!ctx->first_keyframe_received && !is_keyframe &&
+	    os_atomic_load_bool(&ctx->config.wait_for_keyframe)) {
+		if (ctx->total_video_frames == 0)
+			blog(LOG_DEBUG,
+			     "[irl-source] Waiting for keyframe (dropped non-keyframe)");
+		return;
+	}
 
+	if (!ctx->first_keyframe_received && is_keyframe) {
 		ctx->first_keyframe_received = true;
 		ctx->video_corrupted = false;
 		/* hw_frames_ctx on the decoded frame is the ground truth
@@ -329,7 +331,7 @@ void irl_handle_video_frame(struct irl_source *ctx, AVFrame *frame)
 		     frame->hw_frames_ctx ? "hardware" : "software");
 	}
 
-	if (irl_video_is_keyframe(frame))
+	if (is_keyframe)
 		ctx->video_corrupted = false;
 
 	if (ctx->video_corrupted || frame->decode_error_flags != 0) {


### PR DESCRIPTION
Closes [#17.](https://github.com/irlserver/obs-irl-source/issues/17)

The frame level gate now also checks the “Wait for Keyframe” setting before dropping non keyframes. When the setting is disabled decoded frames are passed through immediately.

"first_keyframe_received" is still only set when an actual keyframe arrives so the existing tracking and logging remain accurate