### PR TITLE
fix: redact URL in receiver thread log

### DIFF
--- a/src/receiver.c
+++ b/src/receiver.c
@@ -63,8 +63,7 @@ void *irl_receiver_thread(void *data)
 		return NULL;
 	}
 
-	blog(LOG_INFO, "[irl-source] Receiver thread started for: %s",
-	     ctx->config.url ? ctx->config.url : "(null)");
+	irl_log_input_url("Receiver thread started for", ctx->config.url);
 
 	/* A new thread means a new stream configuration (create, or a
 	 * restart-forcing settings edit): nothing learned about the previous


### PR DESCRIPTION
Sorry it looks like I missed one raw URL log in [#18.](https://github.com/irlserver/obs-irl-source/pull/18)

The receiver thread still logged the complete URL on startup. This routes that message through the same redacted URL logger as the other connection messages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved receiver startup logging to display the configured input URL consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->